### PR TITLE
Fixed a bug with noauth still requiring auth types

### DIFF
--- a/spoofer/commands/cli.py
+++ b/spoofer/commands/cli.py
@@ -7,13 +7,13 @@ def run(args):
     appdescription.print_description()
 
     # Connect to SMTP over TLS
-    connection = SMTPConnection(args.host, str(args.port))
+    connection = SMTPConnection(args.host, str(args.port), args.noauth)
 
     # Attempt login
     if not args.noauth:
         success = connection.login(args.username, args.password)
         if success:
-            logger.success('Authentication successful')
+            logger.success("Authentication successful")
         else:
             exit(1)
 
@@ -26,13 +26,8 @@ def run(args):
 
     # Compose MIME message
     message = connection.compose_message(
-        args.sender,
-        args.name,
-        args.recipients,
-        args.subject,
-        message_body
+        args.sender, args.name, args.recipients, args.subject, message_body
     )
 
-    if get_yes_no('Send message (Y/N)?: ', None):
+    if get_yes_no("Send message (Y/N)?: ", None):
         connection.send_mail(message)
-

--- a/spoofer/commands/wizard.py
+++ b/spoofer/commands/wizard.py
@@ -8,69 +8,61 @@ from ..models.smtpconnection import SMTPConnection
 def run(args):
     appdescription.print_description()
 
-    host = get_required('SMTP host: ')
-    port = None;
+    host = get_required("SMTP host: ")
+    port = None
 
     while not port:
         try:
-            port = int(get_required('SMTP port: '))
+            port = int(get_required("SMTP port: "))
             if port < 0 or port > 65535:
-                logger.error('SMTP port is out-of-range (0-65535)')
+                logger.error("SMTP port is out-of-range (0-65535)")
                 port = None
         except ValueError:
-            logger.error('SMTP port must be a number')
+            logger.error("SMTP port must be a number")
             port = None
 
     # Connect to SMTP over TLS
-    connection = SMTPConnection(host, str(port))
 
     # Attempt login
-    if not get_yes_no("Disable authentication (Y/N)?: ", 'n'):
+    if not get_yes_no("Disable authentication (Y/N)?: ", "n"):
+        connection = SMTPConnection(host, str(port))
         success = False
         while not success:
-            success = connection.login(
-                get_required('Username: '),
-                getpass()
-            )
-        logger.success('Authentication successful')
+            success = connection.login(get_required("Username: "), getpass())
+        logger.success("Authentication successful")
+    else:
+        connection = SMTPConnection(host, str(port), noauth=True)
+    sender = get_required("Sender address: ")
+    sender_name = get_required("Sender name: ")
 
-    sender = get_required('Sender address: ')
-    sender_name = get_required('Sender name: ');
-
-    recipients = [get_required('Recipient address: ')]
-    if get_yes_no('Enter additional recipients (Y/N)?: ', 'n'):
-        recipient = True;
+    recipients = [get_required("Recipient address: ")]
+    if get_yes_no("Enter additional recipients (Y/N)?: ", "n"):
+        recipient = True
         while recipient:
-            recipient = get_optional('Recipient address: ', None)
+            recipient = get_optional("Recipient address: ", None)
             if recipient:
                 recipients.append(recipient)
 
-    subject = get_required('Subject line: ')
+    subject = get_required("Subject line: ")
 
-    html = ''
-    if get_yes_no('Load message body from file (Y/N)?: ', 'n'):
-        filename = get_required('Filename: ')
+    html = ""
+    if get_yes_no("Load message body from file (Y/N)?: ", "n"):
+        filename = get_required("Filename: ")
         with open(filename) as f:
             html = f.read()
     else:
-        logger.info('Enter HTML line by line')
-        logger.info('To finish, press CTRL+D (*nix) or CTRL-Z (win) on an *empty* line')
+        logger.info("Enter HTML line by line")
+        logger.info("To finish, press CTRL+D (*nix) or CTRL-Z (win) on an *empty* line")
         while True:
             try:
-                line = prompt('>| ', Fore.LIGHTBLACK_EX)
-                html += line + '\n'
+                line = prompt(">| ", Fore.LIGHTBLACK_EX)
+                html += line + "\n"
             except EOFError:
-                logger.success('Captured HTML body')
+                logger.success("Captured HTML body")
                 break
 
     # Compose MIME message
-    message = connection.compose_message(
-        sender,
-        sender_name,
-        recipients,
-        subject,
-        html
-    )
+    message = connection.compose_message(sender, sender_name, recipients, subject, html)
 
-    if get_yes_no('Send message (Y/N)?: ', None):
+    if get_yes_no("Send message (Y/N)?: ", None):
         connection.send_mail(message)

--- a/spoofer/models/smtpconnection.py
+++ b/spoofer/models/smtpconnection.py
@@ -5,98 +5,108 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from ..utils import logger
 
+
 class SMTPConnection:
-    def __init__(self, host, port):
+    def __init__(self, host, port, noauth=False):
         self.host = host
         self.port = port
-        self.socket  = host + ':' + port
-        self.server  = None
+        self.socket = host + ":" + port
+        self.server = None
         self.sender = None
         self.recipients = None
 
         self.__connect()
         self.__start_tls()
-        self.__eval_server_features()
+        if not noauth:
+            self.__eval_server_features()
 
     def __ehlo(self):
         try:
             self.server.ehlo()
             if not self.server.does_esmtp:
-                logger.error('The server does not support ESMTP')
+                logger.error("The server does not support ESMTP")
                 exit(1)
         except smtplib.SMTPHeloError:
-            logger.error('The server did not reply properly to the EHLO/HELO greeting.')
+            logger.error("The server did not reply properly to the EHLO/HELO greeting.")
             exit(1)
 
     def __connect(self):
         try:
-            logger.info('Connecting to SMTP socket (' + self.socket + ')...')
+            logger.info("Connecting to SMTP socket (" + self.socket + ")...")
             self.server = smtplib.SMTP(self.host, self.port)
         except (gaierror, OSError):
-            logger.error('Unable to establish connection to SMTP socket.')
+            logger.error("Unable to establish connection to SMTP socket.")
             exit(1)
 
     def __start_tls(self):
         self.__ehlo()
-        if not self.server.has_extn('starttls'):
-            logger.error('SMTP server does not support TLS.')
+        if not self.server.has_extn("starttls"):
+            logger.error("SMTP server does not support TLS.")
             exit(1)
         else:
             try:
-                logger.info('Starting TLS session...')
+                logger.info("Starting TLS session...")
                 self.server.starttls()
             except RuntimeError:
-                logger.error('SSL/TLS support is not available to your Python interpreter.')
+                logger.error(
+                    "SSL/TLS support is not available to your Python interpreter."
+                )
                 exit(1)
 
     def __eval_server_features(self):
         self.__ehlo()
 
-        if not self.server.has_extn('auth'):
-            logger.error('No AUTH types detected.')
+        if not self.server.has_extn("auth"):
+            logger.error("No AUTH types detected.")
             exit(1)
 
-        server_auth_features = self.server.esmtp_features.get('auth').strip().split()
-        supported_auth_features = { auth_type for auth_type in {'PLAIN', 'LOGIN'} if auth_type in server_auth_features }
+        server_auth_features = self.server.esmtp_features.get("auth").strip().split()
+        supported_auth_features = {
+            auth_type
+            for auth_type in {"PLAIN", "LOGIN"}
+            if auth_type in server_auth_features
+        }
 
         if not supported_auth_features:
-            logger.error('SMTP server does not support AUTH PLAIN or AUTH LOGIN.')
+            logger.error("SMTP server does not support AUTH PLAIN or AUTH LOGIN.")
             exit(1)
 
     def login(self, username, password):
         try:
             return self.server.login(username, password)
         except smtplib.SMTPAuthenticationError:
-            logger.error('The server did not accept the username/password combination.')
+            logger.error("The server did not accept the username/password combination.")
             return False
         except smtplib.SMTPNotSupportedError:
-            logger.error('The AUTH command is not supported by the server.')
+            logger.error("The AUTH command is not supported by the server.")
             exit(1)
         except smtplib.SMTPException:
-            logger.error('Encountered an error during authentication.')
+            logger.error("Encountered an error during authentication.")
             exit(1)
 
     def compose_message(self, sender, name, recipients, subject, html):
         self.sender = sender
         self.recipients = recipients
 
-        message = MIMEMultipart('alternative')
+        message = MIMEMultipart("alternative")
         message.set_charset("utf-8")
 
-        message["From"] = name + "<" +  self.sender + ">"
-        message['Subject'] = subject
-        message["To"] = ', '.join(self.recipients)
+        message["From"] = name + "<" + self.sender + ">"
+        message["Subject"] = subject
+        message["To"] = ", ".join(self.recipients)
 
-        body = MIMEText(html, 'html')
+        body = MIMEText(html, "html")
         message.attach(body)
-        return message;
+        return message
 
     def send_mail(self, message):
         try:
-            logger.info('Sending spoofed message...')
+            logger.info("Sending spoofed message...")
             self.server.sendmail(self.sender, self.recipients, message.as_string())
-            logger.success('Message sent!')
+            logger.success("Message sent!")
         except smtplib.SMTPException:
-            logger.error('Unable to send message. Check sender, recipients and message body')
+            logger.error(
+                "Unable to send message. Check sender, recipients and message body"
+            )
             logger.error(traceback.format_exc())
             exit(1)


### PR DESCRIPTION
Added a `noauth` field on initialization of SMTPConnection to determine whether or not to call `__eval_server_features`. When spoofing an email directly to the target SMTP server, (such as M365), port 25 won't have any auth types available, and the tool would error out. This just disables that check, so the email can be sent.

Also, it looks like black may have adjusted some formatting!